### PR TITLE
Fixed failing test case in the function `af_predictions()`

### DIFF
--- a/tests/testthat/test-AlphaFold.R
+++ b/tests/testthat/test-AlphaFold.R
@@ -23,7 +23,7 @@ test_that("af_predictions() works", {
         tbl <- af_predictions(c("P35557", "xyz")),
         "1 of 2 uniprot accessions not found\n  'xyz'"
     )
-    expect_identical(dim(tbl), c(1L, 20L))
+    expect_identical(dim(tbl), c(1L, 21L))
 })
 
 test_that("af_colorfunc_by_position() works", {


### PR DESCRIPTION
Dimensions of `af_predictions()` tbl has changed. 

The `tbl` consists of 21 columns as given below, previously the test case was checking for 20 columns.

```
> names(tbl)
 [1] "entryId"                "gene"                   "uniprotAccession"       "uniprotId"             
 [5] "uniprotDescription"     "taxId"                  "organismScientificName" "uniprotStart"          
 [9] "uniprotEnd"             "uniprotSequence"        "modelCreatedDate"       "latestVersion"         
[13] "allVersions"            "isReviewed"             "isReferenceProteome"    "cifUrl"                
[17] "bcifUrl"                "pdbUrl"                 "paeImageUrl"            "paeDocUrl"             
[21] "amAnnotationsUrl"
```